### PR TITLE
WIP: Rethink keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const path = require('path');
 const CHARS = { '{': '}', '(': ')', '[': ']'};
 const STRICT = /\\(.)|(^!|\*|[\].+)]\?|\[[^\\\]]+\]|\{[^\\}]+\}|\(\?[:!=][^\\)]+\)|\([^|]+\|[^\\)]+\)|(\\).|([@?!+*]\(.*\)))/;
 const RELAXED = /\\(.)|(^!|[*?{}()[\]]|\(\?)/;
+const TRIM = /^(.\/|\/)/;
 
 /**
  * Detect if a string cointains glob
@@ -69,8 +70,7 @@ function globalyzer(pattern, opts = {}) {
   let glob;
 
   if (base != '.') {
-    glob = pattern.substr(base.length);
-    if (glob.startsWith('/')) glob = glob.substr(1);
+    glob = pattern.replace(TRIM, '').substr(base.replace(TRIM, '').length);
   } else {
     glob = pattern;
   }
@@ -80,8 +80,7 @@ function globalyzer(pattern, opts = {}) {
     glob = base !== '.' ? pattern.substr(base.length) : pattern;
   }
 
-  if (glob.startsWith('./')) glob = glob.substr(2);
-  if (glob.startsWith('/')) glob = glob.substr(1);
+  glob = glob.replace(TRIM, '');
 
   return { base, glob, isGlob };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -129,7 +129,7 @@ test('isGlob', t => {
   ['\\!\\*.js', '\\!foo', '\\!foo.js', '\\*(foo).js', '\\*.js', '\\*\\*/abc.js', 'abc/\\*.js'].forEach(x => {
     t.false($(x).isGlob);
   });
-  
+
   // should be false if it is not a glob pattern
   ['', '~/abc', '~/abc', '~/(abc)', '+~(abc)', '.', '@.(abc)', 'aa', 'who?', 'why!?', 'where???',
   'abc!/def/!ghi.js', 'abc.js', 'abc/def/!ghi.js', 'abc/def/ghi.js'].forEach(x => {
@@ -191,7 +191,7 @@ test('isGlob', t => {
   });
 
   t.true($('abc/(a|b\\).js', {strict: false}));
- 
+
   // should be true if the path has a regex character class
   ['abc/[abc].js', 'abc/[^abc].js', 'abc/[1-3].js'].forEach(x => {
     t.true($(x).isGlob);

--- a/test/index.js
+++ b/test/index.js
@@ -61,14 +61,14 @@ test('base', t => {
     ['path/**/*', 'path'],
     ['path/**/subdir/foo.*', 'path'],
     ['path/subdir/**/foo.js', 'path/subdir'],
-    ['path/!subdir/foo.js', 'path/!subdir'],
+    ['path/!subdir/foo.js', 'path'],
     // should respect escaped characters
-    ['path/\\*\\*/subdir/foo.*', 'path/**/subdir'],
-    ['path/\\[\\*\\]/subdir/foo.*', 'path/[*]/subdir'],
+    ['path/\\*\\*/subdir/foo.*', 'path'],
+    ['path/\\[\\*\\]/subdir/foo.*', 'path'],
     ['path/\\*(a|b)/subdir/foo.*', 'path'],
-    ['path/\\*/(a|b)/subdir/foo.*', 'path/*'],
-    ['path/\\*\\(a\\|b\\)/subdir/foo.*', 'path/*(a|b)/subdir'],
-    ['path/\\[foo bar\\]/subdir/foo.*', 'path/[foo bar]/subdir'],
+    ['path/\\*/(a|b)/subdir/foo.*', 'path'],
+    ['path/\\*\\(a\\|b\\)/subdir/foo.*', 'path'],
+    ['path/\\[foo bar\\]/subdir/foo.*', 'path'],
     ['path/\\[bar]/', 'path'],
     ['path/foo \\[bar]/', 'path'],
     // should return parent dirname from non-glob paths
@@ -117,7 +117,7 @@ test('glob', t => {
   });
 
   t.end();
-})
+});
 
 test('isGlob', t => {
   // should be true if it is a glob pattern


### PR DESCRIPTION
So, I definitely don't have the background or familiarity you do with glob patterns & the whole approach. There are RegExps in here that I don't know what they were/are doing 😅 I'm just poking around.

This version gets all `tiny-glob` tests to pass and it _feels_ more correct than what was happening.

This purposefully drops support for directories that are named with RegExp-like characters; eg: `foo/?/bar`, `foo/+/bar`, `foo/!/bar`, `foo/!sub/bar`, `foo/(b c)/bar`,  etc. To me, these ***are*** patterns and should be treated as such.

Because of this, some of the tests' expectants changed, resulting in different `base` and `isGlob` values.

---

I left logs in place so that if/when you run this, you can see more info surrounding the changes.