### PR TITLE
Fixes for various paths

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function isglob(str, { strict = true } = {}) {
  * @returns {String} static path section of glob
  */
 function parent(str, { strict = false } = {}) {
-  str = path.normalize(str).replace(/\/|\\/, '/');
+  str = path.posix.normalize(str);
 
   // special case for strings ending in enclosure containing path separator
   if (/[\{\[].*[\/]*.*[\}\]]$/.test(str)) str += '/';
@@ -73,6 +73,8 @@ function globalyzer(pattern, opts = {}) {
   if (base != '.') {
     glob = pattern.substr(base.length);
     if (glob.startsWith('/')) glob = glob.substr(1);
+    // resolve `../` withing paths
+    glob = path.posix.normalize(glob)
   } else {
     glob = pattern;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,8 @@ function parent(str, { strict = false } = {}) {
  * @returns {Object} object with parsed path
  */
 function globalyzer(pattern, opts = {}) {
+  if (pattern.startsWith('./')) pattern = pattern.substr(2);
+
   let base = parent(pattern, opts);
   let isGlob = isglob(pattern, opts);
   let glob;


### PR DESCRIPTION
Hi,

I've seen that terkelg/tiny-glob#42 was blocked by a failing test, after investigating I could pinpoint it to two cases where the globalyzer could not properly parse the path

Case 1: The glob path included a `../` eg `fixtures/../*` which was not properly resolved
Case 2: the `./` was part of the pattern and this did not allow to simply subtract the `base.length`
This create the situation that `./test/*.{js,txt}` was interpreted as a `st/*.{js,txt}`

It would be cool if this finds it's way into tiny-glob :)

Have a great day.